### PR TITLE
Fix charts

### DIFF
--- a/client-ui/src/components/BusinessOutcomesChart/index.tsx
+++ b/client-ui/src/components/BusinessOutcomesChart/index.tsx
@@ -27,7 +27,8 @@ const BusinessOutcomesChart: FC<BusinessOutcomesChartProps> = ({ individualData 
     const outcomeCounts = individualData.reduce((acc: Record<string, number>, item) => {
         const outcome = item.business_outcome;
         if (outcome) {
-            acc[outcome] = (acc[outcome] || 0) + 1;
+            const firstTwoWords = outcome.split(' ').slice(0, 2).join(' ').toLowerCase();
+            acc[firstTwoWords] = (acc[firstTwoWords] || 0) + 1;
         }
         return acc;
     }, {});

--- a/client-ui/src/components/NpsCsatScores/index.tsx
+++ b/client-ui/src/components/NpsCsatScores/index.tsx
@@ -9,18 +9,18 @@ interface NpsCsatScoresProps {
 const NpsCsatScores: FC<NpsCsatScoresProps> = ({ nps, csat }) => {
     return (
         <Stack orientation="horizontal" spacing="space60">
-            <Box>
-                <Heading as="h3" variant="heading30">
-                    Average NPS Score
-                </Heading>
-                <Paragraph>{nps.toFixed(2)}</Paragraph>
-            </Box>
-            <Box>
-                <Heading as="h3" variant="heading30">
-                    Average CSAT Score
-                </Heading>
-                <Paragraph>{csat.toFixed(2)}</Paragraph>
-            </Box>
+          <Box padding="space60" backgroundColor="colorBackground" borderRadius="borderRadius20" borderStyle="solid" borderWidth="borderWidth10" borderColor="colorBorder">
+            <Heading as="h3" variant="heading30">
+              Average NPS Score
+            </Heading>
+            <Paragraph>{nps.toFixed(2)}</Paragraph>
+          </Box>
+          <Box padding="space60" backgroundColor="colorBackground" borderRadius="borderRadius20" borderStyle="solid" borderWidth="borderWidth10" borderColor="colorBorder">
+            <Heading as="h3" variant="heading30">
+              Average CSAT Score
+            </Heading>
+            <Paragraph>{csat.toFixed(2)}</Paragraph>
+          </Box>
         </Stack>
     );
 };

--- a/client-ui/src/components/OperatorUsageChart/index.tsx
+++ b/client-ui/src/components/OperatorUsageChart/index.tsx
@@ -1,60 +1,96 @@
-// src/components/OperatorUsageChart/index.tsx
-
 import { FC } from "react";
-import { Bar } from "react-chartjs-2";
+import { Doughnut } from "react-chartjs-2";
 import {
     Chart as ChartJS,
     CategoryScale,
     LinearScale,
-    BarElement,
+    ArcElement,
     Title,
     Tooltip,
     Legend,
 } from "chart.js";
 import { OperatorResult } from "../../types/OperatorResult";
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, ArcElement, Title, Tooltip, Legend);
 
 interface OperatorUsageChartProps {
     operatorResults: OperatorResult[];
 }
 
+// @ts-ignore
 const OperatorUsageChart: FC<OperatorUsageChartProps> = ({ operatorResults }) => {
-    const operatorCounts = operatorResults.reduce((acc: Record<string, number>, result) => {
-        acc[result.name] = (acc[result.name] || 0) + 1;
-        return acc;
-    }, {});
+    const operatorNames = ["Prod_CallDisposition", "Password Reset", "Call Transfer", "Unavailable-Party", "Voicemail Detector", "RecordingDisclosureOperator", "Entity Recognition", "Lead generation"];
 
-    const sortedOperators = Object.entries(operatorCounts).sort(([, a], [, b]) => b - a);
+    return (
+      <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-around' }}>
+          {operatorNames.map(name => {
+              const resultsForName = operatorResults.filter(result => result.name === name);
+              const operatorCounts = resultsForName.reduce((acc: Record<string, number>, result) => {
+                  if (result.name == "Lead generation" || result.name == "Entity Recognition" || result.name == "RecordingDisclosureOperator") {
+                      const keys = result.extract_results ? [...Object.keys(result.extract_results), "No Class"] : ["No Class"];
+                      for (const i in keys){
+                          acc[keys[i]] = (acc[keys[i]] || 0) + 1;
+                      }
+                  }
+                  else {
+                      const label = result.predicted_label;
+                      acc[label] = (acc[label] || 0) + 1;
+                  }
+                  return acc;
+              }, {});
 
-    const chartData = {
-        labels: sortedOperators.map(([name]) => name),
-        datasets: [
-            {
-                label: "Operator Usage",
-                data: sortedOperators.map(([, count]) => count),
-                backgroundColor: "rgba(75, 192, 192, 0.2)",
-                borderColor: "rgba(75, 192, 192, 1)",
-                borderWidth: 1,
-            },
-        ],
-    };
+              const sortedOperators = Object.entries(operatorCounts).sort(([, a], [, b]) => b - a);
 
-    const options = {
-        responsive: true,
-        plugins: {
-            legend: {
-                display: true,
-                position: "top" as const,
-            },
-            title: {
-                display: true,
-                text: "Operator Usage",
-            },
-        },
-    };
+              const chartData = {
+                  labels: sortedOperators.map(([label]) => label),
+                  datasets: [
+                      {
+                          label: `${name} Usage`,
+                          data: sortedOperators.map(([, count]) => count),
+                          backgroundColor: [
+                              'rgba(255, 99, 132, 0.2)',
+                              'rgba(54, 162, 235, 0.2)',
+                              'rgba(255, 206, 86, 0.2)',
+                              'rgba(75, 192, 192, 0.2)',
+                              'rgba(153, 102, 255, 0.2)',
+                              'rgba(255, 159, 64, 0.2)'
+                          ],
+                          borderColor: [
+                              'rgba(255, 99, 132, 1)',
+                              'rgba(54, 162, 235, 1)',
+                              'rgba(255, 206, 86, 1)',
+                              'rgba(75, 192, 192, 1)',
+                              'rgba(153, 102, 255, 1)',
+                              'rgba(255, 159, 64, 1)'
+                          ],
+                          borderWidth: 1,
+                      },
+                  ],
+              };
 
-    return <Bar data={chartData} options={options} />;
+              const options = {
+                  responsive: true,
+                  aspectRatio: 1,
+                  plugins: {
+                      legend: {
+                          display: true,
+                          position: "top" as const,
+                      },
+                      title: {
+                          display: true,
+                          text: `${name}`,
+                      },
+                  },
+              };
+
+              return (
+                <div style={{ flex: '1 0 200px', margin: '10px' }} key={name}>
+                    <Doughnut key={name} data={chartData} options={options} />
+                </div>
+              );
+          })}
+      </div>
+    );
 };
 
 export default OperatorUsageChart;

--- a/client-ui/src/types/OperatorResult.ts
+++ b/client-ui/src/types/OperatorResult.ts
@@ -13,6 +13,8 @@ export interface OperatorResult {
     match_probability?: number;
     predicted_probability?: number;
     utterance_results?: UtteranceResult[];
+    predicted_label: string;
+    extract_match?: boolean;
 }
 
 export interface UtteranceResult {

--- a/serverless/src/functions/api/analyse-openai.ts
+++ b/serverless/src/functions/api/analyse-openai.ts
@@ -58,7 +58,7 @@ export const handler: ServerlessFunctionSignature<MyContext, MyEvent> =
     const prompt = [
       {
         role: "system",
-        content: `Anaylse this customer service interaction, respond back with a JSON object with the keys {"sentiment","business_outcome","summary", "intervention_required","predicted_nps_score","predicted_csat_score"}`,
+        content: `Anaylse this customer service interaction. Any negative business_outcome like loss of sale, failure to place order should be classified as negative sentiment. Successful orders should be considered positive sentiment. Respond back with a JSON object with the keys {"sentiment","business_outcome","summary", "intervention_required","predicted_nps_score","predicted_csat_score"}`,
       },
     ];
 


### PR DESCRIPTION
- Moved to a stacked chart for Sentiment Trends
- Minor fixes to sentiment analysis prompt
- Fixed the business outcome chart to group similar business outcomes
- Added a doughnut chart for each operator type
- Cleaned up the NPS metrics to give them a KPI card look


![image](https://github.com/twilio-cfeehan/twilio-vintel-addon-example/assets/61987883/81731791-3aa0-4b34-b0ba-aacedb9fd24e)

![image](https://github.com/twilio-cfeehan/twilio-vintel-addon-example/assets/61987883/d75083f1-84cb-4bf9-9cdf-76ec68a019a5)
